### PR TITLE
vscode doesn't recognize [masm] or [asm] (and using file associations…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,15 +30,6 @@
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true
   },
-  "[masm]": {
-    "editor.detectIndentation": false,
-    "editor.insertSpaces": false,
-    "editor.tabSize": 8,
-    "files.eol": "\r\n",
-    "files.trimTrailingWhitespace": true,
-    "files.insertFinalNewline": true,
-    "files.trimFinalNewlines": true
-  },
   "[xml][xsl]": {
     "editor.insertSpaces": false,
     "editor.tabSize": 4,


### PR DESCRIPTION
… breaks color coding), so all assembly language files must rely on default editor settings, and all other file types must override those defaults as needed